### PR TITLE
Improve wave detection UX with automatic threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Bodyboard GPX/CSV – Détection de vagues</title>
+  <title>Bodyboard GPX/CSV Â· DÃ©tection de vagues</title>
 
-  <!-- Leaflet (CDN, aucune clé requise) -->
+  <!-- Leaflet (CDN, aucune clÃ© requise) -->
   <link
     rel="stylesheet"
     href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -25,68 +25,95 @@
 <body>
   <header>
     <h1>Bodyboard Session Viewer</h1>
-    <div class="file-controls">
-      <label class="file">
-        <input type="file" id="fileInput" accept=".gpx,.csv" />
-        <span>?? Charger un fichier (GPX/CSV)</span>
-      </label>
-      <button id="fitBtn" disabled>??? Recentrer carte</button>
-      <button id="clearBtn" disabled>?? Effacer</button>
-    </div>
   </header>
 
   <main>
     <section class="sidebar">
       <div class="panel">
-        <h2>Résumé de la session</h2>
+        <h2><span class="step">1</span> Importer une trace</h2>
+        <div class="controls controls-inline">
+          <label class="file">
+            <input type="file" id="fileInput" accept=".gpx,.csv" />
+            <span>Charger un fichier (GPX/CSV)</span>
+          </label>
+          <div class="actions">
+            <button id="fitBtn" disabled>Recentrer la carte</button>
+            <button id="clearBtn" disabled>Effacer</button>
+          </div>
+        </div>
+        <small>Formats pris en charge : GPX (trkseg) et CSV <code>time,lat,lon[,ele]</code>.</small>
+      </div>
+
+      <div class="panel">
+        <h2><span class="step">2</span> RÃ©sumÃ© de la session</h2>
         <dl class="stats" id="stats">
-          <div><dt>Distance totale</dt><dd id="stat-distance">–</dd></div>
-          <div><dt>Durée</dt><dd id="stat-duration">–</dd></div>
-          <div><dt>Vitesse moyenne</dt><dd id="stat-avg">–</dd></div>
-          <div><dt>Vitesse max</dt><dd id="stat-max">–</dd></div>
-          <div><dt>Nombre de vagues</dt><dd id="stat-waves">–</dd></div>
-          <div><dt>Meilleure vague</dt><dd id="stat-best">–</dd></div>
+          <div><dt>Distance totale</dt><dd id="stat-distance"></dd></div>
+          <div><dt>DurÃ©e</dt><dd id="stat-duration"></dd></div>
+          <div><dt>Vitesse moyenne</dt><dd id="stat-avg"></dd></div>
+          <div><dt>Vitesse max</dt><dd id="stat-max"></dd></div>
+          <div><dt>Nombre de vagues</dt><dd id="stat-waves"></dd></div>
+          <div><dt>Meilleure vague</dt><dd id="stat-best"></dd></div>
         </dl>
       </div>
 
       <div class="panel">
-        <h2>Détection des vagues</h2>
+        <h2><span class="step">3</span> DÃ©tection des vagues</h2>
         <div class="controls">
           <label>
             Seuil vitesse (km/h)
-            <input type="range" id="thresholdRange" min="5" max="50" value="15" />
-            <input type="number" id="thresholdNumber" min="5" max="100" step="1" value="15" />
+            <input type="range" id="thresholdRange" min="5" max="50" value="15" step="0.5" />
+            <input type="number" id="thresholdNumber" min="5" max="100" step="0.5" value="15" />
           </label>
           <label>
-            Durée minimale (s)
+            DurÃ©e minimale (s)
             <input type="number" id="minDuration" min="0" step="1" value="2" />
           </label>
-          <button id="detectBtn" disabled>?? Détecter les vagues</button>
+          <button id="detectBtn" disabled>Actualiser les vagues</button>
+          <p class="auto-threshold" id="autoThresholdLabel"></p>
           <label class="legend">
-            Légende vitesse
+            LÃ©gende vitesse
             <div class="gradient" id="legendGradient" title="Couleurs de vitesse"></div>
-            <div class="legend-scale"><span>lent</span><span>rapide</span></div>
+            <div class="legend-scale"><span id="legendMin"></span><span id="legendMax"></span></div>
           </label>
         </div>
       </div>
 
       <div class="panel">
-        <h2>Export</h2>
+        <h2><span class="step">4</span> Vagues dÃ©tectÃ©es</h2>
+        <div class="waves-table" id="wavesTableWrap">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Distance</th>
+                <th>DurÃ©e</th>
+                <th>Vitesse max</th>
+                <th>Vitesse moy.</th>
+              </tr>
+            </thead>
+            <tbody id="wavesTableBody"></tbody>
+          </table>
+          <p class="empty" id="wavesEmpty">Aucune vague dÃ©tectÃ©e pour le moment.</p>
+        </div>
+      </div>
+
+      <div class="panel">
+        <h2><span class="step">5</span> Export</h2>
         <div class="controls">
-          <button id="exportBtn" disabled>?? Exporter en GPX</button>
+          <button id="exportBtn" disabled>Exporter en GPX</button>
           <small>
-            L’export contient la trace complète. Les vagues détectées sont ajoutées en
-            <code>&lt;trk&gt;</code> séparés pour un repérage facile.
+            Lâ€™export contient la trace complÃ¨te. Les vagues dÃ©tectÃ©es sont ajoutÃ©es en
+            <code>&lt;trk&gt;</code> sÃ©parÃ©s pour un repÃ©rage facile.
           </small>
         </div>
       </div>
 
       <div class="panel">
-        <h2>Notes</h2>
+        <h2><span class="step">6</span> Notes</h2>
         <ul class="notes">
-          <li>Fond satellite : ESRI World Imagery (gratuit, sans clé).</li>
+          <li>Fond satellite : ESRI World Imagery (gratuit, sans clÃ©).</li>
           <li>CSV attendu : <code>time,lat,lon[,ele]</code>.</li>
-          <li>La couleur de chaque segment reflète la vitesse (km/h).</li>
+          <li>La couleur des vagues reflÃ¨te la vitesse (km/h).</li>
         </ul>
       </div>
     </section>
@@ -97,7 +124,7 @@
   </main>
 
   <footer>
-    <span>© 2025 – Codage • Bodyboard GPX/CSV</span>
+    <span>Â© 2025 Â· Bodyboard GPX/CSV Session Viewer</span>
   </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -51,9 +51,13 @@ main{
   box-shadow:0 0 0 1px rgba(0,0,0,0.1) inset;
 }
 
-.file-controls{
-  display:flex;gap:.5rem;flex-wrap:wrap
+.controls-inline{
+  display:flex;
+  gap:.75rem;
+  flex-wrap:wrap;
+  align-items:center;
 }
+.actions{display:flex;gap:.5rem;flex-wrap:wrap}
 .file input[type=file]{display:none}
 .file span{
   display:inline-block;
@@ -76,6 +80,12 @@ button:disabled{opacity:.5;cursor:not-allowed}
 }
 .controls input[type=range]{width:100%}
 
+.auto-threshold{
+  margin:0;
+  font-size:.85rem;
+  color:var(--muted);
+}
+
 .stats{
   display:grid;gap:.35rem;margin:0
 }
@@ -83,12 +93,59 @@ button:disabled{opacity:.5;cursor:not-allowed}
 .stats dt{color:var(--muted)}
 .stats dd{margin:0;font-variant-numeric:tabular-nums}
 
+.step{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:1.4rem;height:1.4rem;
+  margin-right:.35rem;
+  background:rgba(76,201,240,0.15);
+  border:1px solid rgba(76,201,240,0.5);
+  border-radius:999px;
+  font-size:.8rem;
+  color:var(--accent);
+  font-weight:700;
+}
+
 .legend{display:grid;gap:.4rem}
 .gradient{
   height:12px;border-radius:6px;border:1px solid var(--border);
   background: linear-gradient(to right, #2b83ba, #abdda4, #ffffbf, #fdae61, #d7191c);
 }
-.legend-scale{display:flex;justify-content:space-between;color:var(--muted);font-size:.85em}
+.legend-scale{display:flex;justify-content:space-between;color:var(--muted);font-size:.85em;font-variant-numeric:tabular-nums}
+
+.waves-table{
+  display:grid;
+  gap:.5rem;
+}
+.waves-table table{
+  width:100%;
+  border-collapse:collapse;
+  font-size:.9rem;
+}
+.waves-table th,
+.waves-table td{
+  text-align:left;
+  padding:.35rem .4rem;
+  border-bottom:1px solid var(--border);
+}
+.waves-table th{
+  color:var(--muted);
+  font-weight:600;
+}
+.waves-table tbody tr{cursor:pointer;}
+.waves-table tbody tr:focus-visible td{
+  outline:2px solid var(--accent);
+  outline-offset:1px;
+}
+.waves-table tr:hover td{
+  background:#111827;
+}
+.waves-table .empty{
+  margin:0;
+  color:var(--muted);
+  font-size:.85rem;
+}
 
 .notes{margin:.25rem 0 0 1rem}
 .notes li{margin:.25rem 0}


### PR DESCRIPTION
## Summary
- reorganize the sidebar into a step-by-step workflow and add a detailed waves table with key metrics
- render the base track in neutral grey while coloring detected waves by speed and updating the legend accordingly
- compute an automatic speed threshold, auto-refresh detection on control changes, and allow focusing the map from the waves list

## Testing
- node -e "new Function(require('fs').readFileSync('app.js','utf8'));"

------
https://chatgpt.com/codex/tasks/task_b_68dd302aec1c8324b52f87ea404244d8