### PR TITLE
Reset file input state after loading traces

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,9 @@ fileInput.addEventListener('change', async (e)=>{
   }catch(err){
     alert('Erreur au chargement: ' + err.message);
     console.error(err);
+  }finally{
+    // Permet de recharger le même fichier sans devoir sélectionner un autre fichier avant
+    fileInput.value = '';
   }
 });
 
@@ -680,6 +683,7 @@ clearBtn.addEventListener('click', ()=>{
   resetStatsUI();
   resetWaveUI();
   setEnabled(false);
+  fileInput.value = '';
 });
 
 minDurationInput.addEventListener('change', ()=>{


### PR DESCRIPTION
## Summary
- clear the file input once a trace is parsed so the same file can be selected again
- reset the file input when clearing the session to keep the upload button responsive

## Testing
- Verified in Playwright that the file input value resets after loading and clearing a trace

------
https://chatgpt.com/codex/tasks/task_b_68de75740c1c8324b2a0510230223314