### PR TITLE
Handle missing Leaflet map gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,15 @@
     </section>
 
     <section class="map-wrap">
-      <div id="map"></div>
+      <div class="map-status" id="mapStatus" role="alert" hidden>
+        <strong>Carte indisponible.</strong>
+        <span>
+          Leaflet n’a pas pu être chargé. Vérifiez votre connexion Internet ou les
+          bloqueurs de contenu, puis rechargez la page. Les autres fonctionnalités
+          restent accessibles sans la carte.
+        </span>
+      </div>
+      <div id="map" aria-live="polite"></div>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -41,6 +41,27 @@ main{
 }
 .map-wrap{position:relative}
 #map{position:absolute;inset:0}
+.map-status{
+  position:absolute;
+  inset:0;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:.5rem;
+  text-align:center;
+  padding:1.5rem;
+  background:rgba(13,17,23,0.92);
+  border:1px solid var(--border);
+  border-radius:12px;
+  color:var(--muted);
+  font-size:.95rem;
+  z-index:10;
+}
+.map-status strong{
+  color:var(--text);
+  font-size:1rem;
+}
 
 .panel{
   background:var(--panel);


### PR DESCRIPTION
## Summary
- display an overlay message when Leaflet fails to load so the UI stays usable without the map
- guard all map-dependent logic to prevent crashes and keep data analysis available even offline
- style the fallback overlay to match the application theme

## Testing
- python3 -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_b_68de7b173eac8324983f35da3233bd55