### PR TITLE
Color detected waves uniformly and add numbered markers

### DIFF
--- a/style.css
+++ b/style.css
@@ -223,3 +223,20 @@ button:disabled{opacity:.5;cursor:not-allowed}
 
 .notes{margin:.25rem 0 0 1rem}
 .notes li{margin:.25rem 0}
+
+.wave-label{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:28px;
+  height:28px;
+  border-radius:999px;
+  background:rgba(15,23,42,0.9);
+  border:2px solid rgba(148,163,184,0.85);
+  color:#e2e8f0;
+  font-weight:700;
+  font-size:0.85rem;
+  text-shadow:0 1px 2px rgba(0,0,0,0.45);
+  transform:translate(-50%, -50%);
+}
+.wave-label span{display:block;line-height:1;}


### PR DESCRIPTION
## Summary
- draw each detected wave using a single color derived from its average speed, and always render arrows showing the direction of travel
- number waves on the map to match the table and extend popups with average speed details
- style the new numbered markers for readability on the satellite basemap

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_b_68dfcc281a708324b512b00220b61431