### PR TITLE
Remove direction arrows and display wave start times

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           </label>
           <label class="toggle">
             <input type="checkbox" id="directionToggle" />
-            <span>Filtrer et dessiner le sens des vagues</span>
+            <span>Filtrer le sens des vagues</span>
           </label>
           <div class="direction-controls">
             <label>
@@ -99,6 +99,7 @@
             <thead>
               <tr>
                 <th>#</th>
+                <th>Début</th>
                 <th>Distance</th>
                 <th>Durée</th>
                 <th>Vitesse max</th>


### PR DESCRIPTION
## Summary
- stop drawing map direction arrows and update the direction filter label
- record each wave start time to show it in the table and map popups

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68dfd2e528888324aff3ae8a2c21aacb